### PR TITLE
feat: 온보딩 공연 램덤 생성

### DIFF
--- a/src/main/java/muse_kopis/muse/performance/domain/PerformanceRepository.java
+++ b/src/main/java/muse_kopis/muse/performance/domain/PerformanceRepository.java
@@ -45,6 +45,9 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
             "WHERE a.name = :favoriteActor")
     List<Performance> findPerformancesByFavoriteActor(@Param("favoriteActor") String favoriteActor);
 
+    @Query(value = "SELECT p FROM Performance p WHERE p.genreType = :genreType ORDER BY FUNCTION('RAND')")
+    List<Performance> findRandomByGenreType(@Param("genreType") GenreType genreType);
+
     List<Performance> findAllByPerformanceNameContains(String search);
     List<Performance> findByPerformanceName(String performanceName);
     List<Performance> findAllByIdIn(List<Long> performanceIds);

--- a/src/main/java/muse_kopis/muse/usergenre/application/UserGenreService.java
+++ b/src/main/java/muse_kopis/muse/usergenre/application/UserGenreService.java
@@ -1,12 +1,23 @@
 package muse_kopis.muse.usergenre.application;
 
+import static muse_kopis.muse.genre.domain.GenreType.CREATIVE_MUSICAL;
+import static muse_kopis.muse.genre.domain.GenreType.ETC_MUSICAL;
+import static muse_kopis.muse.genre.domain.GenreType.LICENSE;
+import static muse_kopis.muse.genre.domain.GenreType.NUMBER_PERFORMANCE;
+import static muse_kopis.muse.genre.domain.GenreType.ORIGINAL_OR_INTERNATIONAL;
+
 import jakarta.transaction.Transactional;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import muse_kopis.muse.auth.oauth.domain.OauthMember;
 import muse_kopis.muse.auth.oauth.domain.OauthMemberRepository;
+import muse_kopis.muse.genre.domain.GenreType;
 import muse_kopis.muse.performance.domain.Performance;
 import muse_kopis.muse.performance.domain.PerformanceRepository;
 import muse_kopis.muse.performance.domain.dto.PerformanceResponse;
@@ -23,6 +34,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserGenreService {
 
+    private final static int totalTarget = 30;
     private final GenreRepository genreRepository;
     private final UserGenreRepository userGenreRepository;
     private final PerformanceRepository performanceRepository;
@@ -73,12 +85,37 @@ public class UserGenreService {
 
     @Transactional
     public List<PerformanceResponse> showOnboarding() {
-        List<Long> performanceIds = Arrays.asList(
-                1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L,
-                11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L,
-                21L, 22L, 23L, 24L, 25L, 26L, 27L, 28L, 29L, 30L
+        List<GenreType> genreTypes = Arrays.asList(
+                ORIGINAL_OR_INTERNATIONAL, CREATIVE_MUSICAL, NUMBER_PERFORMANCE, ETC_MUSICAL, LICENSE
         );
-        List<Performance> performances = performanceRepository.findAllByIdIn(performanceIds);
-        return performances.stream().map(PerformanceResponse::from).toList();
+        int perGenreTarget = totalTarget / genreTypes.size(); // ex. 30개 / 5장르 = 6개
+        Set<Performance> result = new LinkedHashSet<>(); // 중복 방지를 위해 Set 사용
+        // 1. 장르별로 공연 수집 (최대 perGenreTarget개씩)
+        for (GenreType genre : genreTypes) {
+            List<Performance> performances = performanceRepository.findAllByGenreType(genre);
+            Collections.shuffle(performances); // 랜덤 순서
+            int count = 0;
+            for (Performance p : performances) {
+                if (count >= perGenreTarget) break;
+                if (result.add(p)) { // 중복이 아닐 때만 추가
+                    count++;
+                }
+            }
+        }
+        // 2. 부족한 경우 전체 공연에서 보충
+        if (result.size() < totalTarget) {
+            int remaining = totalTarget - result.size();
+            List<Performance> extra = performanceRepository.findAll();
+            Collections.shuffle(extra);
+            for (Performance p : extra) {
+                if (result.size() >= totalTarget) break;
+                result.add(p); // Set이므로 중복 자동 제거
+            }
+        }
+        // 3. 변환 및 결과 반환
+        return result.stream()
+                .limit(totalTarget) // 혹시 초과한 경우 제한
+                .map(PerformanceResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/muse_kopis/muse/usergenre/application/UserGenreService.java
+++ b/src/main/java/muse_kopis/muse/usergenre/application/UserGenreService.java
@@ -92,8 +92,7 @@ public class UserGenreService {
         Set<Performance> result = new LinkedHashSet<>(); // 중복 방지를 위해 Set 사용
         // 1. 장르별로 공연 수집 (최대 perGenreTarget개씩)
         for (GenreType genre : genreTypes) {
-            List<Performance> performances = performanceRepository.findAllByGenreType(genre);
-            Collections.shuffle(performances); // 랜덤 순서
+            List<Performance> performances = performanceRepository.findRandomByGenreType(genre);
             int count = 0;
             for (Performance p : performances) {
                 if (count >= perGenreTarget) break;


### PR DESCRIPTION
기존에 직접 지정해뒀던 온보딩용 공연을 자동으로 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - The onboarding experience now dynamically selects 30 performances, evenly distributed across five specific genres, instead of using a fixed list. If there are not enough performances in these genres, additional performances are randomly selected to reach the total. This ensures a more varied and genre-representative onboarding selection for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->